### PR TITLE
Improve b2a and dabits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,22 +19,6 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FLINT DEFAULT_MSG FLINT_INCLUDE_DIR FLINT_LIBRARIES)
 mark_as_advanced(FLINT_INCLUDE_DIR FLINT_LIBRARIES)
 
-find_package(OpenMP REQUIRED)
-
-# Palisade
-find_package(Palisade)
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PALISADE_CXX_FLAGS}" )
-set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${PALISADE_EXE_LINKER_FLAGS}" )
-include_directories( ${OPENMP_INCLUDES} )
-include_directories( ${PALISADE_INCLUDE} )
-include_directories( ${PALISADE_INCLUDE}/third-party/include )
-include_directories( ${PALISADE_INCLUDE}/core )
-include_directories( ${PALISADE_INCLUDE}/pke )
-### add directories for other PALISADE modules as needed for your project
-link_directories( ${PALISADE_LIBDIR} )
-link_directories( ${OPENMP_LIBRARIES} )
-link_libraries( ${PALISADE_LIBRARIES} )
-
 include(cmake/common.cmake)
 find_package(EMP-TOOL REQUIRED)
 include_directories(${EMP-TOOL_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
@@ -43,7 +27,7 @@ foreach(_target
   server client
 )
   add_executable(${_target} "${_target}.cpp" 
-                 "constants.cpp" "ot.cpp" "fmpz_utils.cpp" "share.cpp" "net_share.cpp" "correlated.cpp" "he_triples.cpp"
+                 "constants.cpp" "ot.cpp" "fmpz_utils.cpp" "share.cpp" "net_share.cpp" "correlated.cpp"
                  "poly/fft.c" "poly/poly_once.c" "poly/poly_batch.c"
                  )
   target_link_libraries(${_target}
@@ -52,16 +36,13 @@ foreach(_target
     ${GMP_LIBRARIES}
     ${EMP-TOOL_LIBRARIES}
     ${FLINT_LIBRARIES}
-    OpenMP::OpenMP_CXX
   )
 endforeach()
 
 set(test_poly "test_circuit" "test_linreg")
 set(test_correlated "test_ot" "test_bits")
-# store has triples
-set(test_he_triples "test_he_triples" ${test_correlated})
 # stuff that sends shares
-set(test_net_share "test_net_share" ${test_poly} ${test_correlated} ${test_he_triples})
+set(test_net_share "test_net_share" ${test_poly} ${test_correlated})
 set(test_share "test_share" ${test_net_share})
 foreach(_target
   test_net_share
@@ -69,7 +50,6 @@ foreach(_target
   test_linreg
   test_ot
   test_bits
-  test_he_triples
 )
   set (test_SOURCE_FILES "test/${_target}.cpp")
   set (test_SOURCE_FILES ${test_SOURCE_FILES} "constants.cpp" "fmpz_utils.cpp")
@@ -86,9 +66,6 @@ foreach(_target
   if (_target IN_LIST test_correlated)
     set (test_SOURCE_FILES ${test_SOURCE_FILES} "correlated.cpp" "ot.cpp")
   endif()
-  if (_target IN_LIST test_he_triples)
-    set (test_SOURCE_FILES ${test_SOURCE_FILES} "he_triples.cpp")
-  endif()
   list(REMOVE_DUPLICATES test_SOURCE_FILES)
   # message(STATUS "${_target}: ${test_SOURCE_FILES}")
   add_executable(${_target} ${test_SOURCE_FILES})
@@ -98,6 +75,5 @@ foreach(_target
     ${GMP_LIBRARIES}
     ${EMP-TOOL_LIBRARIES}
     ${FLINT_LIBRARIES}
-    OpenMP::OpenMP_CXX
   )
 endforeach()

--- a/README.md
+++ b/README.md
@@ -14,20 +14,12 @@ Some of this code, such as the fast polynomial operations, is directly based on 
 
 1. [Flint 2.7.0+](https://flintlib.org)
 2. [emp-ot](https://github.com/emp-toolkit/emp-ot)
-3. [PALISADE](https://gitlab.com/palisade/palisade-release)
 
 # Getting Started
 
 ## Install dependencies
 
 Follow the links above to install the corresponding packages
-
-### PALISADE Instructions
-
-For full install instructions, see [here](https://gitlab.com/palisade/palisade-release/-/wikis/Build-instructions).  
-Currently, Palisade is built with default args (`cmake ..`).
-
-PALISADE encryption is used to generate beaver triples.
 
 ## Build Prio+
 

--- a/client.cpp
+++ b/client.cpp
@@ -1339,7 +1339,7 @@ void lin_reg_invalid(const std::string protocol, const size_t numreqs) {
         if (i == 8)
             fmpz_add_si(packet1[i]->triple_share->shareA, packet1[i]->triple_share->shareA, 1);
 
-        // 10 vs 11, 12 vs 13 can be non-deterministic which ends up being right. 
+        // 10 vs 11, 12 vs 13 can be non-deterministic which ends up being right.
         if (i <= 9 or i == 11 or i == 13) {
             // std::cout << " (invalid)" << std::endl;
         } else {

--- a/correlated.cpp
+++ b/correlated.cpp
@@ -21,26 +21,6 @@ void CorrelatedStore::addBoolTriples(const size_t n) {
   std::cout << "addBoolTriples timing : " << sec_from(start) << std::endl;
 }
 
-void CorrelatedStore::addTriples(const size_t n) {
-  auto start = clock_start();
-  const size_t num_to_make = (n > batch_size ? n : batch_size);
-  std::cout << "adding triples: " << num_to_make << std::endl;
-  if (triple_gen) {  // not null pointer
-    std::vector<BeaverTriple*> new_triples = triple_gen->generateTriples(num_to_make);
-    for (unsigned int i = 0; i < num_to_make; i++)
-      atriple_store.push(new_triples[i]);
-  } else {
-    std::cout << "Using lazy beaver triples" << std::endl;
-    // std::cout << "Using OT beaver triples" << std::endl;
-    for (unsigned int i = 0; i < num_to_make; i++) {
-      BeaverTriple* triple = generate_beaver_triple_lazy(serverfd, server_num);
-      // BeaverTriple* triple = generate_beaver_triple(serverfd, server_num, ot0, ot1);
-      atriple_store.push(triple);
-    }
-  }
-  std::cout << "addTriples timing : " << sec_from(start) << std::endl;
-}
-
 void CorrelatedStore::addDaBits(const size_t n) {
   auto start = clock_start();
   const size_t num_to_make = (n > batch_size ? n : batch_size);
@@ -50,7 +30,7 @@ void CorrelatedStore::addDaBits(const size_t n) {
     for (unsigned int i = 0; i < num_to_make; i++)
       dabit_store.push(dabit[i]);
     delete[] dabit;
-  } else {
+  } else {  // Lazy generation: make local and send over
     DaBit** const dabit = new DaBit*[num_to_make];
     for (unsigned int i = 0; i < num_to_make; i++)
       dabit[i] = new DaBit;
@@ -77,86 +57,18 @@ void CorrelatedStore::addDaBits(const size_t n) {
   std::cout << "addDaBits timing : " << sec_from(start) << std::endl;
 }
 
-void CorrelatedStore::addEdaBits(const size_t num_bits, const size_t n) {
-  auto start = clock_start();
-  const size_t num_to_make = (n > batch_size ? n : batch_size);
-  std::cout << "adding " << num_bits << " bit edabits: " << num_to_make << std::endl;
-  std::cout << "Note: edaBits are deprecated" << std::endl;
-  if (lazy) {
-    if (server_num == 0) {  // make on server 0
-      std::cout << "Making lazy edabits" << std::endl;
-      EdaBit* other_edabit = new EdaBit(num_bits);
-      for (unsigned int i = 0; i < num_to_make; i++) {
-        EdaBit* edabit = new EdaBit(num_bits);
-        makeLocalEdaBit(edabit, other_edabit, num_bits);
-        send_EdaBit(serverfd, other_edabit, num_bits);  // TODO: batch
-        if (num_bits == nbits)
-          edabit_store.push(edabit);
-        else if (num_bits == 2 * nbits)
-          edabit_store_2.push(edabit);
-      }
-      delete other_edabit;
-    } else {
-      for (unsigned int i = 0; i < num_to_make; i++) {
-        EdaBit* edabit = new EdaBit(num_bits);
-        recv_EdaBit(serverfd, edabit, num_bits);
-        if (num_bits == nbits)
-          edabit_store.push(edabit);
-        else if (num_bits == 2 * nbits)
-          edabit_store_2.push(edabit);
-      }
-    }
-    std::cout << "lazy addEdaBits timing : " << sec_from(start) << std::endl;
-    return;
-  }
-
-  EdaBit** edabit = generateEdaBit(num_to_make, num_bits);
-  for (unsigned int i = 0; i < num_to_make; i++) {
-    if (num_bits == nbits)
-      edabit_store.push(edabit[i]);
-    else if (num_bits == 2 * nbits)
-      edabit_store_2.push(edabit[i]);
-  }
-  delete[] edabit;
-
-  std::cout << "addEdaBits timing : " << sec_from(start) << std::endl;
-}
-
 void CorrelatedStore::checkBoolTriples(const size_t n) { 
   if (btriple_store.size() < n) addBoolTriples(n - btriple_store.size());
-}
-
-void CorrelatedStore::checkTriples(const size_t n, const bool always) { 
-  if ((!lazy or always) and atriple_store.size() < n) addTriples(n - atriple_store.size());
 }
 
 void CorrelatedStore::checkDaBits(const size_t n) { 
   if (dabit_store.size() < n) addDaBits(n - dabit_store.size());
 }
 
-void CorrelatedStore::checkEdaBits(const size_t num_bits, const size_t n) { 
-  if (num_bits == nbits) {
-    if (edabit_store.size() < n) addEdaBits(num_bits, n - edabit_store.size());
-  } else if (num_bits == 2 * nbits) {
-    if (edabit_store_2.size() < n) addEdaBits(num_bits, n - edabit_store_2.size());
-  } else {
-    std::cerr << "Don't support " << num_bits << " bit edabits" << std::endl;
-    std::cerr << "Only " << nbits << " or " << 2 * nbits << " is supported" << std::endl;
-    exit(EXIT_FAILURE);
-  }
-}
-
 BooleanBeaverTriple* CorrelatedStore::getBoolTriple() {
   checkBoolTriples(1);
   BooleanBeaverTriple* ans = btriple_store.front();
   btriple_store.pop();
-  return ans;
-}
-
-BeaverTriple* CorrelatedStore::getTriple() {
-  checkTriples(1);
-  BeaverTriple* ans = atriple_store.front();
-  atriple_store.pop();
   return ans;
 }
 
@@ -167,65 +79,26 @@ DaBit* CorrelatedStore::getDaBit() {
   return ans;
 }
 
-EdaBit* CorrelatedStore::getEdaBit(const size_t num_bits) {
-  checkEdaBits(num_bits, 1);
-  EdaBit* ans;
-  if (num_bits == nbits) {
-    ans = edabit_store.front();
-    edabit_store.pop();
-    return ans;
-  } else if (num_bits == 2 * nbits) {
-    ans = edabit_store_2.front();
-    edabit_store_2.pop();
-  } else {
-    std::cerr << "Cannot get a " << num_bits << " bit edabits" << std::endl;
-    std::cerr << "Only " << nbits << " or " << 2 * nbits << " is supported" << std::endl;
-    exit(EXIT_FAILURE);
-  }
-
-  return ans;
-}
-
 void CorrelatedStore::printSizes() {
   std::cout << "Current store sizes:" << std::endl;
-  // std::cout << "       EdaBits: " << edabit_store.size() << std::endl;
-  // std::cout << "     EdaBits 2: " << edabit_store_2.size() << std::endl;
   std::cout << "        Dabits: " << dabit_store.size() << std::endl;
-  std::cout << " Arith Triples: " << atriple_store.size() << std::endl;
   std::cout << " Bool  Triples: " << btriple_store.size() << std::endl;
 }
 
-void CorrelatedStore::maybeUpdate(const bool using_eda) {
-  std::cout << "precomputing using " << (using_eda?"deprecated e":"") << "dabits..." << std::endl;
+void CorrelatedStore::maybeUpdate() {
   auto start = clock_start();
 
-  // If making extra
-  const size_t extra = over_precompute ? 1 : 0;
   // Make top level if stores not enough
-  const bool make_eda = using_eda && (edabit_store.size() < batch_size / 2);
-  const bool make_eda2 = using_eda && (edabit_store_2.size() < batch_size / 2);
-  const bool make_da = !using_eda && (dabit_store.size() < batch_size * nbits / 2);
+  const bool make_da = dabit_store.size() < (batch_size * nbits / 2);
   // Determine how much of each to make
-  const size_t da_target = (using_eda 
-                            ? (make_eda + make_eda2 + extra) 
-                            : (2 * make_da * nbits));
-  const size_t atrip_target = da_target + extra;
-  const size_t btrip_target = using_eda ? (2 * (make_eda + 2 * make_eda2) + extra) : 0;
+  const size_t da_target = 2 * make_da * nbits;
+  const size_t btrip_target = 0;
 
   if (btriple_store.size() < btrip_target * bool_batch_size)
       addBoolTriples(btrip_target * bool_batch_size);
 
-  if (!lazy) {
-    if (atriple_store.size() < atrip_target * batch_size)
-      addTriples(atrip_target * batch_size);
-  }
-  if (!lazy or !using_eda) {
-    if (dabit_store.size() < da_target * batch_size)
-      addDaBits(da_target * batch_size);
-  }
-
-  if (make_eda) addEdaBits(nbits);
-  if (make_eda2) addEdaBits(2 * nbits);
+  if (dabit_store.size() < da_target * batch_size)
+    addDaBits(da_target * batch_size);
 
   printSizes();
 
@@ -233,33 +106,16 @@ void CorrelatedStore::maybeUpdate(const bool using_eda) {
 }
 
 CorrelatedStore::~CorrelatedStore() {
-  while (!edabit_store.empty()) {
-    EdaBit* bit = edabit_store.front();
-    edabit_store.pop();
-    delete bit;
-  }
-  while (!edabit_store_2.empty()) {
-    EdaBit* bit = edabit_store_2.front();
-    edabit_store_2.pop();
-    delete bit;
-  }
   while (!dabit_store.empty()) {
     DaBit* bit = dabit_store.front();
     dabit_store.pop();
     delete bit;
-  }
-  while (!atriple_store.empty()) {
-    BeaverTriple* triple = atriple_store.front();
-    atriple_store.pop();
-    delete triple;
   }
   while (!btriple_store.empty()) {
     BooleanBeaverTriple* triple = btriple_store.front();
     btriple_store.pop();
     delete triple;
   }
-  if (triple_gen)
-    delete triple_gen;
 }
 
 bool* CorrelatedStore::multiplyBoolShares(const size_t N,
@@ -310,72 +166,9 @@ bool* CorrelatedStore::multiplyBoolShares(const size_t N,
   return z;
 }
 
-fmpz_t* CorrelatedStore::multiplyArithmeticShares(const size_t N,
-                                                  const fmpz_t* const x,
-                                                  const fmpz_t* const y) {
-  fmpz_t* z; new_fmpz_array(&z, N);
-
-  fmpz_t* d; new_fmpz_array(&d, N);
-  fmpz_t* e; new_fmpz_array(&e, N);
-  fmpz_t* d_other; new_fmpz_array(&d_other, N);
-  fmpz_t* e_other; new_fmpz_array(&e_other, N);
-
-  checkTriples(N, true);
-
-  for (unsigned int i = 0; i < N; i++) {
-    BeaverTriple* triple = getTriple();
-
-    fmpz_sub(d[i], x[i], triple->A);  // [d] = [x] - [a]
-    fmpz_mod(d[i], d[i], Int_Modulus);
-    fmpz_sub(e[i], y[i], triple->B);  // [e] = [y] - [b]
-    fmpz_mod(e[i], e[i], Int_Modulus);
-
-    fmpz_set(z[i], triple->C);
-
-    // consume the triple
-    delete triple;
-  }
-
-  // Spawn a child to do the sending, so that can recieve at the same time
-  pid_t pid = 0;
-  int status = 0;
-  if (do_fork) pid = fork();
-  if (pid == 0) {
-    send_fmpz_batch(serverfd, d, N);
-    send_fmpz_batch(serverfd, e, N);
-    if (do_fork) exit(EXIT_SUCCESS);
-  }
-  recv_fmpz_batch(serverfd, d_other, N);
-  recv_fmpz_batch(serverfd, e_other, N);
-
-  for (unsigned int i = 0; i < N; i++) {
-    fmpz_add(d[i], d[i], d_other[i]);  // x - a
-    fmpz_mod(d[i], d[i], Int_Modulus);
-    fmpz_add(e[i], e[i], e_other[i]);  // y - b
-    fmpz_mod(e[i], e[i], Int_Modulus);
-
-    // [xy] = [c] + [x] e + [y] d - de
-    // Is it more efficient using a tmp for product, and modding more?
-    fmpz_addmul(z[i], x[i], e[i]);
-    fmpz_addmul(z[i], y[i], d[i]);
-    if (server_num == 0)
-      fmpz_submul(z[i], d[i], e[i]);
-    fmpz_mod(z[i], z[i], Int_Modulus);
-  }
-
-  clear_fmpz_array(d_other, N);
-  clear_fmpz_array(e_other, N);
-  clear_fmpz_array(d, N);
-  clear_fmpz_array(e, N);
-
-  // Wait for send child to finish
-  if (do_fork) waitpid(pid, &status, 0);
-
-  return z;
-}
-
 // c_{i+1} = c_i xor ((x_i xor c_i) and (y_i xor c_i))
 // output z_i = x_i xor y_i xor c_i
+// Unused
 bool* CorrelatedStore::addBinaryShares(const size_t N,
                                        const size_t* const num_bits,
                                        const bool* const * const x,
@@ -509,95 +302,6 @@ fmpz_t* CorrelatedStore::b2a_daBit_multi(const size_t N,
   return xp;
 }
 
-// Deprecated
-fmpz_t* CorrelatedStore::b2a_edaBit(const size_t N,
-                                    const size_t* const num_bits,
-                                    const fmpz_t* const x) {
-  std::cout << "b2a_edaBit is deprecated. Use b2a_daBit_multi for less rounds" << std::endl;
-  size_t num_n = 0, num_2n = 0;
-  for (unsigned int i = 0; i < N; i++) {
-    if (num_bits[i] == nbits) num_n += 1;
-    if (num_bits[i] == 2 * nbits) num_2n += 1;
-  }
-  const size_t eda_to_make = (edabit_store.size() < num_n) ? num_n - edabit_store.size() : 0;
-  const size_t eda2_to_make = (edabit_store_2.size() < num_2n) ? num_2n - edabit_store_2.size() : 0;
-  const size_t da_target = eda_to_make + eda2_to_make;
-  const size_t bool_target = (1 + !lazy) * nbits * (eda_to_make + 2 * eda2_to_make);
-
-  checkBoolTriples(bool_target);
-  checkTriples(da_target);
-  checkDaBits(da_target);
-  checkEdaBits(nbits, num_n);
-  checkEdaBits(2 * nbits, num_2n);
-
-  fmpz_t* xp; new_fmpz_array(&xp, N);
-
-  bool** x2 = new bool*[N];
-  bool** b = new bool*[N];
-  bool** xr = new bool*[N];
-  fmpz_t* ebit_r; new_fmpz_array(&ebit_r, N);
-
-  for (unsigned int i = 0; i < N; i++) {
-    x2[i] = new bool[num_bits[i]];
-    b[i] = new bool[num_bits[i]];
-    xr[i] = new bool[num_bits[i] + 1];
-    EdaBit* edabit = getEdaBit(num_bits[i]);
-    for (unsigned int j = 0; j < num_bits[i]; j++) {
-      // Convert x2 to bool array
-      x2[i][j] = fmpz_tstbit(x[i], j);
-      b[i][j] = edabit->b[j];
-    }
-    fmpz_set(ebit_r[i], edabit->r);
-
-    // consume edabit
-    delete edabit;
-  }
-
-  // [x + r]_2 = [x]_2 + [r]_2 via circuit
-  bool* carry = addBinaryShares(N, num_bits, x2, b, xr);
-
-  for (unsigned int i = 0; i < N; i++) {
-    xr[i][num_bits[i]] = carry[i];
-
-    fmpz_from_bool_array(xp[i], xr[i], num_bits[i] + 1);  // [x + r]_2
-
-    delete[] x2[i];
-    delete[] b[i];
-    delete[] xr[i];
-  }
-  delete[] carry;
-  delete[] x2;
-  delete[] b;
-  delete[] xr;
-
-  // reveal x + r, convert to mod p shares
-  if (server_num == 0) {
-    fmpz_t* xr_other; new_fmpz_array(&xr_other, N);
-    recv_fmpz_batch(serverfd, xr_other, N);  // get other [x + r]_2
-    for (unsigned int i = 0; i < N; i++) {
-      fmpz_xor(xp[i], xp[i], xr_other[i]);  // real x + r
-      fmpz_randm(xr_other[i], seed, Int_Modulus);  // make other [x + r]_p
-      fmpz_sub(xp[i], xp[i], xr_other[i]);
-      fmpz_mod(xp[i], xp[i], Int_Modulus);  // This [x + r]_p
-    }
-    send_fmpz_batch(serverfd, xr_other, N);
-    clear_fmpz_array(xr_other, N);
-  } else {
-    send_fmpz_batch(serverfd, xp, N);
-    recv_fmpz_batch(serverfd, xp, N);
-  }
-
-  // [x]_p = [x+r]_p - [r]_p
-  for (unsigned int i = 0; i < N; i++) {
-    fmpz_sub(xp[i], xp[i], ebit_r[i]);
-    fmpz_mod(xp[i], xp[i], Int_Modulus);
-  }
-
-  clear_fmpz_array(ebit_r, N);
-
-  return xp;
-}
-
 // Using intsum_ot, multiple bits
 fmpz_t* CorrelatedStore::b2a_ot(const size_t num_shares, const size_t num_values, 
                                 const size_t* const num_bits,
@@ -678,146 +382,4 @@ DaBit** CorrelatedStore::generateDaBit(const size_t N) {
   delete[] x;
 
   return dabit;
-}
-
-// Outdated, slower making and using arith triples vs just OT
-/*
-DaBit** CorrelatedStore::generateDaBit_triple(const size_t N) {
-  DaBit** const dabit = new DaBit*[N];
-
-  DaBit** const dabit0 = new DaBit*[N];
-  DaBit** const dabit1 = new DaBit*[N];
-  fmpz_t* x; new_fmpz_array(&x, N);
-  fmpz_t* y; new_fmpz_array(&y, N);
-
-  for (unsigned int i = 0; i < N; i++) {
-    dabit[i] = new DaBit();
-
-    // Create local
-    dabit0[i] = new DaBit();
-    dabit1[i] = new DaBit();
-    makeLocalDaBit(dabit0[i], dabit1[i]);
-  }
-  // Exchange
-  pid_t pid = 0;
-  int status = 0;
-  if (do_fork) pid = fork();
-  if (pid == 0) {
-    send_DaBit_batch(serverfd, server_num == 0 ? dabit1 : dabit0, N);
-    if (do_fork) exit(EXIT_SUCCESS);
-  }
-
-  recv_DaBit_batch(serverfd, server_num == 0 ? dabit1 : dabit0, N);
-  for (unsigned int i = 0; i < N; i++) {
-    // Xor boolean shares
-    dabit[i]->b2 = dabit0[i]->b2 ^ dabit1[i]->b2;
-
-    fmpz_set(x[i], dabit0[i]->bp);
-    fmpz_set(y[i], dabit1[i]->bp);
-
-    delete dabit0[i];
-    delete dabit1[i];
-  }
-  delete[] dabit0;
-  delete[] dabit1;
-
-  if (do_fork) waitpid(pid, &status, 0);
-
-  // Xor Arithmetic shares, using a xor b = a + b - 2ab
-  fmpz_t* z = multiplyArithmeticShares(N, x, y);
-
-  for (unsigned int i = 0; i < N; i++) {
-    fmpz_add(dabit[i]->bp, x[i], y[i]);
-    fmpz_submul_ui(dabit[i]->bp, z[i], 2);
-    fmpz_mod(dabit[i]->bp, dabit[i]->bp, Int_Modulus);
-  }
-
-  clear_fmpz_array(x, N);
-  clear_fmpz_array(y, N);
-  clear_fmpz_array(z, N);
-
-  return dabit;
-}
-*/
-
-EdaBit** CorrelatedStore::generateEdaBit(const size_t N, const size_t num_bits) {
-  EdaBit** edabit = new EdaBit*[N];
-
-  EdaBit** edabit0 = new EdaBit*[N];
-  EdaBit** edabit1 = new EdaBit*[N];
-  bool** b = new bool*[N];
-  bool** b0 = new bool*[N];
-  bool** b1 = new bool*[N];
-
-  for (unsigned int i = 0; i < N; i++) {
-    edabit[i] = new EdaBit(num_bits);
-
-    // Create local
-    edabit0[i] = new EdaBit(num_bits);
-    edabit1[i] = new EdaBit(num_bits);
-    makeLocalEdaBit(edabit0[i], edabit1[i], num_bits);
-  }
-  // Exchange
-  pid_t pid = 0;
-  int status = 0;
-  if (do_fork) pid = fork();
-  if (pid == 0) {
-    send_EdaBit_batch(serverfd, server_num == 0 ? edabit1 : edabit0, num_bits, N);
-    if (do_fork) exit(EXIT_SUCCESS);
-  }
-
-  recv_EdaBit_batch(serverfd, server_num == 0 ? edabit1 : edabit0, num_bits, N);
-  for (unsigned int i = 0; i < N; i++) {
-    // Add arithmetic shares
-    fmpz_add(edabit[i]->r, edabit0[i]->r, edabit1[i]->r);
-    fmpz_mod(edabit[i]->r, edabit[i]->r, Int_Modulus);
-
-    b[i] = new bool[num_bits];
-    b0[i] = new bool[num_bits];
-    b1[i] = new bool[num_bits];
-    memcpy(b0[i], edabit0[i]->b, num_bits * sizeof(bool));
-    memcpy(b1[i], edabit1[i]->b, num_bits * sizeof(bool));
-
-    delete edabit0[i];
-    delete edabit1[i];
-  }
-  delete[] edabit0;
-  delete[] edabit1;
-
-  if (do_fork) waitpid(pid, &status, 0);
-
-  // Add binary shares via circuit
-  size_t* bits_arr = new size_t[N];
-  for (unsigned int i = 0; i < N; i++)
-    bits_arr[i] = num_bits;
-  bool* carry = addBinaryShares(N, bits_arr, b0, b1, b);
-  delete[] bits_arr;
-
-  fmpz_t tmp; fmpz_init(tmp);
-  fmpz_from_bool_array(tmp, b[0], num_bits);
-
-  // Convert carry to arithmetic [carry]_p
-  fmpz_t* carry_p = b2a_daBit_single(N, carry);
-  delete[] carry;
-
-  // Subtract out 2^n * [carry]_p from r
-  fmpz_t pow; fmpz_init_set_ui(pow, 2);
-  fmpz_pow_ui(pow, pow, num_bits);
-  for (unsigned int i = 0; i < N; i++) {
-    fmpz_submul(edabit[i]->r, carry_p[i], pow);
-    fmpz_mod(edabit[i]->r, edabit[i]->r, Int_Modulus);
-
-    memcpy(edabit[i]->b, b[i], num_bits * sizeof(bool));
-
-    delete[] b[i];
-    delete[] b0[i];
-    delete[] b1[i];
-  }
-  delete[] b;
-  delete[] b0;
-  delete[] b1;
-  clear_fmpz_array(carry_p, N);
-  fmpz_clear(pow);
-
-  return edabit;
 }

--- a/correlated.cpp
+++ b/correlated.cpp
@@ -81,8 +81,8 @@ DaBit* CorrelatedStore::getDaBit() {
 
 void CorrelatedStore::printSizes() {
   std::cout << "Current store sizes:" << std::endl;
-  std::cout << "        Dabits: " << dabit_store.size() << std::endl;
-  std::cout << " Bool  Triples: " << btriple_store.size() << std::endl;
+  std::cout << " Dabits: " << dabit_store.size() << std::endl;
+  // std::cout << " Bool  Triples: " << btriple_store.size() << std::endl;
 }
 
 void CorrelatedStore::maybeUpdate() {

--- a/correlated.cpp
+++ b/correlated.cpp
@@ -81,6 +81,7 @@ void CorrelatedStore::addEdaBits(const size_t num_bits, const size_t n) {
   auto start = clock_start();
   const size_t num_to_make = (n > batch_size ? n : batch_size);
   std::cout << "adding " << num_bits << " bit edabits: " << num_to_make << std::endl;
+  std::cout << "Note: edaBits are deprecated" << std::endl;
   if (lazy) {
     if (server_num == 0) {  // make on server 0
       std::cout << "Making lazy edabits" << std::endl;
@@ -187,15 +188,15 @@ EdaBit* CorrelatedStore::getEdaBit(const size_t num_bits) {
 
 void CorrelatedStore::printSizes() {
   std::cout << "Current store sizes:" << std::endl;
-  std::cout << "       EdaBits: " << edabit_store.size() << std::endl;
-  std::cout << "     EdaBits 2: " << edabit_store_2.size() << std::endl;
+  // std::cout << "       EdaBits: " << edabit_store.size() << std::endl;
+  // std::cout << "     EdaBits 2: " << edabit_store_2.size() << std::endl;
   std::cout << "        Dabits: " << dabit_store.size() << std::endl;
   std::cout << " Arith Triples: " << atriple_store.size() << std::endl;
   std::cout << " Bool  Triples: " << btriple_store.size() << std::endl;
 }
 
 void CorrelatedStore::maybeUpdate(const bool using_eda) {
-  std::cout << "precomputing using " << (using_eda?"e":"") << "dabits..." << std::endl;
+  std::cout << "precomputing using " << (using_eda?"deprecated e":"") << "dabits..." << std::endl;
   auto start = clock_start();
 
   // If making extra
@@ -508,9 +509,11 @@ fmpz_t* CorrelatedStore::b2a_daBit_multi(const size_t N,
   return xp;
 }
 
+// Deprecated
 fmpz_t* CorrelatedStore::b2a_edaBit(const size_t N,
                                     const size_t* const num_bits,
                                     const fmpz_t* const x) {
+  std::cout << "b2a_edaBit is deprecated. Use b2a_daBit_multi for less rounds" << std::endl;
   size_t num_n = 0, num_2n = 0;
   for (unsigned int i = 0; i < N; i++) {
     if (num_bits[i] == nbits) num_n += 1;

--- a/correlated.cpp
+++ b/correlated.cpp
@@ -187,32 +187,44 @@ EdaBit* CorrelatedStore::getEdaBit(const size_t num_bits) {
 
 void CorrelatedStore::printSizes() {
   std::cout << "Current store sizes:" << std::endl;
-  // std::cout << "       EdaBits: " << edabit_store.size() << std::endl;
-  // std::cout << "     EdaBits 2: " << edabit_store_2.size() << std::endl;
+  std::cout << "       EdaBits: " << edabit_store.size() << std::endl;
+  std::cout << "     EdaBits 2: " << edabit_store_2.size() << std::endl;
   std::cout << "        Dabits: " << dabit_store.size() << std::endl;
   std::cout << " Arith Triples: " << atriple_store.size() << std::endl;
   std::cout << " Bool  Triples: " << btriple_store.size() << std::endl;
 }
 
-void CorrelatedStore::maybeUpdate() {
-  std::cout << "precomputing..." << std::endl;
+void CorrelatedStore::maybeUpdate(const bool using_eda) {
+  std::cout << "precomputing using " << (using_eda?"e":"") << "dabits..." << std::endl;
   auto start = clock_start();
+
+  // If making extra
   const size_t extra = over_precompute ? 1 : 0;
-  // Make necessary triples/da for edabits, if needed
-  const bool make_da = dabit_store.size() < batch_size * nbits / 2;  // no 2?
-  const size_t da_target = 2 * make_da * nbits;
+  // Make top level if stores not enough
+  const bool make_eda = using_eda && (edabit_store.size() < batch_size / 2);
+  const bool make_eda2 = using_eda && (edabit_store_2.size() < batch_size / 2);
+  const bool make_da = !using_eda && (dabit_store.size() < batch_size * nbits / 2);
+  // Determine how much of each to make
+  const size_t da_target = (using_eda 
+                            ? (make_eda + make_eda2 + extra) 
+                            : (2 * make_da * nbits));
   const size_t atrip_target = da_target + extra;
-  // Some for making edabits, some for b2a
-  const size_t btrip_target = 0; //2 * (make_eda + 2 * make_eda2) + extra;
+  const size_t btrip_target = using_eda ? (2 * (make_eda + 2 * make_eda2) + extra) : 0;
 
   if (btriple_store.size() < btrip_target * bool_batch_size)
       addBoolTriples(btrip_target * bool_batch_size);
+
   if (!lazy) {
     if (atriple_store.size() < atrip_target * batch_size)
       addTriples(atrip_target * batch_size);
   }
-  if (dabit_store.size() < da_target * batch_size)
-    addDaBits(da_target * batch_size);
+  if (!lazy or !using_eda) {
+    if (dabit_store.size() < da_target * batch_size)
+      addDaBits(da_target * batch_size);
+  }
+
+  if (make_eda) addEdaBits(nbits);
+  if (make_eda2) addEdaBits(2 * nbits);
 
   printSizes();
 
@@ -426,6 +438,7 @@ fmpz_t* CorrelatedStore::b2a_daBit_single(const size_t N, const bool* const x) {
     // consume the daBit
     delete dabit;
   }
+
   pid_t pid = 0;
   int status = 0;
   if (do_fork) pid = fork();
@@ -434,9 +447,9 @@ fmpz_t* CorrelatedStore::b2a_daBit_single(const size_t N, const bool* const x) {
 
     if (do_fork) exit(EXIT_SUCCESS);
   }
-
   bool* v_other = new bool[N];
   recv_bool_batch(serverfd, v_other, N);
+
   for (unsigned int i = 0; i < N; i++) {
     const bool v = v_this[i] ^ v_other[i];
 

--- a/correlated.cpp
+++ b/correlated.cpp
@@ -125,8 +125,8 @@ void CorrelatedStore::checkBoolTriples(const size_t n) {
   if (btriple_store.size() < n) addBoolTriples(n - btriple_store.size());
 }
 
-void CorrelatedStore::checkTriples(const size_t n) { 
-  if (!lazy and atriple_store.size() < n) addTriples(n - atriple_store.size());
+void CorrelatedStore::checkTriples(const size_t n, const bool always) { 
+  if ((!lazy or always) and atriple_store.size() < n) addTriples(n - atriple_store.size());
 }
 
 void CorrelatedStore::checkDaBits(const size_t n) { 
@@ -319,7 +319,7 @@ fmpz_t* CorrelatedStore::multiplyArithmeticShares(const size_t N,
   fmpz_t* d_other; new_fmpz_array(&d_other, N);
   fmpz_t* e_other; new_fmpz_array(&e_other, N);
 
-  checkTriples(N);
+  checkTriples(N, true);
 
   for (unsigned int i = 0; i < N; i++) {
     BeaverTriple* triple = getTriple();

--- a/correlated.cpp
+++ b/correlated.cpp
@@ -57,11 +57,11 @@ void CorrelatedStore::addDaBits(const size_t n) {
   std::cout << "addDaBits timing : " << sec_from(start) << std::endl;
 }
 
-void CorrelatedStore::checkBoolTriples(const size_t n) { 
+void CorrelatedStore::checkBoolTriples(const size_t n) {
   if (btriple_store.size() < n) addBoolTriples(n - btriple_store.size());
 }
 
-void CorrelatedStore::checkDaBits(const size_t n) { 
+void CorrelatedStore::checkDaBits(const size_t n) {
   if (dabit_store.size() < n) addDaBits(n - dabit_store.size());
 }
 
@@ -303,7 +303,7 @@ fmpz_t* CorrelatedStore::b2a_daBit_multi(const size_t N,
 }
 
 // Using intsum_ot, multiple bits
-fmpz_t* CorrelatedStore::b2a_ot(const size_t num_shares, const size_t num_values, 
+fmpz_t* CorrelatedStore::b2a_ot(const size_t num_shares, const size_t num_values,
                                 const size_t* const num_bits,
                                 const fmpz_t* const x, const size_t mod) {
   uint64_t** x2 = new uint64_t*[num_shares];

--- a/correlated.h
+++ b/correlated.h
@@ -12,6 +12,9 @@ New batches are build either as it runs out, or by calling maybeUpdate
 
 edaBit related logic for share conversion based on ia.cr/2020/338
 
+edaBits are deprecated. Require L rounds for L bits. Multiple dabits is 1 round.
+edaBit code left in for legacy.
+
 Due to send buffers potentially filling up, it forks out a child to do sending, while parent receives
 It also waits for the child to finish before exiting or moving to a substep that will send, to stay synced
 */
@@ -47,15 +50,17 @@ class CorrelatedStore {
   // nbits * batch_size
   const size_t bool_batch_size;
 
+  // Deprecated
   std::queue<EdaBit*> edabit_store;    // nbits edabits
   std::queue<EdaBit*> edabit_store_2;  // 2 nbits edabits
+
   std::queue<DaBit*> dabit_store;
   std::queue<BooleanBeaverTriple*> btriple_store;
   std::queue<BeaverTriple*> atriple_store;
 
   // return N new daBits
   DaBit** generateDaBit(const size_t N);
-  // return N new edaBits
+  // return N new edaBits. Deprecated
   EdaBit** generateEdaBit(const size_t N, const size_t num_bits);
 
   // add to the store.
@@ -63,12 +68,14 @@ class CorrelatedStore {
   void addBoolTriples(const size_t n = 0);
   void addTriples(const size_t n = 0);
   void addDaBits(const size_t n = 0);
+  // Deprecated
   void addEdaBits(const size_t num_bits, const size_t n = 0);
 
   // check if enough to make n. if not, call add
   void checkBoolTriples(const size_t n = 0);
   void checkTriples(const size_t n = 0, const bool always = false);
   void checkDaBits(const size_t n = 0);
+  // Deprecated
   void checkEdaBits(const size_t num_bits, const size_t n = 0);
 
   OT_Wrapper* const ot0;
@@ -112,6 +119,7 @@ public:
   BooleanBeaverTriple* getBoolTriple();
   BeaverTriple* getTriple();
   DaBit* getDaBit();
+  // Deprecated
   EdaBit* getEdaBit(const size_t num_bits);
 
   void printSizes();
@@ -144,6 +152,7 @@ public:
   fmpz_t* b2a_daBit_multi(const size_t N, const size_t* const num_bits,
                           const fmpz_t* const x);
   // Multiple bits. Uses one edabit, which requires L rounds for L bits.
+  // Deprecated
   fmpz_t* b2a_edaBit(const size_t N, const size_t* const num_bits,
                      const fmpz_t* const x);
 

--- a/correlated.h
+++ b/correlated.h
@@ -10,10 +10,8 @@ Also includes io objects for OT, which have their own precomputes
 CorrelatedStore maintains a cache of precomputes, made in batch_size chunks at a time to reduce rounds
 New batches are build either as it runs out, or by calling maybeUpdate
 
-edaBit related logic for share conversion based on ia.cr/2020/338
-
-edaBits are deprecated. Require L rounds for L bits. Multiple dabits is 1 round.
-edaBit code left in for legacy.
+For now, only uses DaBits for b2a Share conversion.
+boolean beaver triples are supported as they are straightforward, but not currently made.
 
 Due to send buffers potentially filling up, it forks out a child to do sending, while parent receives
 It also waits for the child to finish before exiting or moving to a substep that will send, to stay synced
@@ -24,7 +22,6 @@ It also waits for the child to finish before exiting or moving to a substep that
 #include <queue>
 
 #include "constants.h"
-#include "he_triples.h"
 #include "ot.h"
 #include "share.h"
 
@@ -38,45 +35,25 @@ class CorrelatedStore {
 
   // If lazy, does fast but insecure offline.
   const bool lazy;
-  // If set, makes extra objects for precomputing. 
-  // E.g. makes n edabits, then also n dabits in case the edabits run out
-  // Allows for remaking edabits if they run out, without being from scratch
-  const bool over_precompute;
-
-  // Arithmetic triple generator
-  ArithTripleGenerator* triple_gen = nullptr;
 
   // Since we use these a lot more, make much bigger batches at once.
   // nbits * batch_size
   const size_t bool_batch_size;
 
-  // Deprecated
-  std::queue<EdaBit*> edabit_store;    // nbits edabits
-  std::queue<EdaBit*> edabit_store_2;  // 2 nbits edabits
-
   std::queue<DaBit*> dabit_store;
   std::queue<BooleanBeaverTriple*> btriple_store;
-  std::queue<BeaverTriple*> atriple_store;
 
   // return N new daBits
   DaBit** generateDaBit(const size_t N);
-  // return N new edaBits. Deprecated
-  EdaBit** generateEdaBit(const size_t N, const size_t num_bits);
 
   // add to the store.
   // Adds at least batch_size (or bool_batch_size), or n if bigger
   void addBoolTriples(const size_t n = 0);
-  void addTriples(const size_t n = 0);
   void addDaBits(const size_t n = 0);
-  // Deprecated
-  void addEdaBits(const size_t num_bits, const size_t n = 0);
 
   // check if enough to make n. if not, call add
   void checkBoolTriples(const size_t n = 0);
-  void checkTriples(const size_t n = 0, const bool always = false);
   void checkDaBits(const size_t n = 0);
-  // Deprecated
-  void checkEdaBits(const size_t num_bits, const size_t n = 0);
 
   OT_Wrapper* const ot0;
   OT_Wrapper* const ot1;
@@ -90,26 +67,19 @@ public:
   CorrelatedStore(const int serverfd, const int idx,
                   OT_Wrapper* const ot0, OT_Wrapper* const ot1,
                   const size_t nbits, const size_t batch_size,
-                  const bool lazy = false, const bool do_fork = true,
-                  const bool over_precompute = true)
+                  const bool lazy = false, const bool do_fork = true)
   : batch_size(batch_size)
   , server_num(idx)
   , serverfd(serverfd)
   , nbits(nbits)
   , lazy(lazy)
-  , over_precompute(over_precompute)
   , bool_batch_size(batch_size * nbits)
   , ot0(ot0)
   , ot1(ot1)
   , do_fork(do_fork)
   {
     if (lazy) {
-      std::cout << "Doing fast but insecure precomputes." << std::endl;
-    } else if (fmpz_cmp_ui(Int_Modulus, 1ULL << 49) < 0) {
-      std::cout << "Using PALISADE SHE arith triples" << std::endl;
-      triple_gen = new ArithTripleGenerator(serverfd, server_num);
-    } else {
-      std::cout << "Mod big, using slower arith triples" << std::endl;
+      std::cout << "Doing fast but insecure dabit precomputes." << std::endl;
     }
   }
 
@@ -117,16 +87,11 @@ public:
 
   // get from store, and maybe add if necessary
   BooleanBeaverTriple* getBoolTriple();
-  BeaverTriple* getTriple();
   DaBit* getDaBit();
-  // Deprecated
-  EdaBit* getEdaBit(const size_t num_bits);
 
   void printSizes();
   // Precompute if not enough.
-  // if eda = true, generates edabits
-  // otherwise makes dabits for dabit_multi
-  void maybeUpdate(const bool using_eda = false);
+  void maybeUpdate();
 
   // compute with store elements. Does batches of size N.
 
@@ -134,12 +99,11 @@ public:
   // does ret[i] = x[i] * y[i], as shares
   bool* multiplyBoolShares(const size_t N,
                            const bool* const x, const bool* const y);
-  fmpz_t* multiplyArithmeticShares(const size_t N,
-                                   const fmpz_t* const x, const fmpz_t* const y);
 
   // x, y, z are [N][num_bits], ret is [N]
   // Treats x[i], y[i], z[i] as array of bits
   // sets z[i] and ret[i] as x[i] + y[i] and carry[i], as shares
+  // Currently unused
   bool* addBinaryShares(const size_t N, const size_t* const num_bits,
                         const bool* const * const x, const bool* const * const y,
                         bool* const * const z);
@@ -151,10 +115,6 @@ public:
   // Multiple bits. Use a dabit per bit in parallel, so one round
   fmpz_t* b2a_daBit_multi(const size_t N, const size_t* const num_bits,
                           const fmpz_t* const x);
-  // Multiple bits. Uses one edabit, which requires L rounds for L bits.
-  // Deprecated
-  fmpz_t* b2a_edaBit(const size_t N, const size_t* const num_bits,
-                     const fmpz_t* const x);
 
   // Using intsum_ot, multiple bits
   // TODO: shift mod to fmpz

--- a/correlated.h
+++ b/correlated.h
@@ -136,9 +136,12 @@ public:
 
   // x, ret is [N]
   // Turns binary share x[i] into arith share ret[i]
-  // Single bit
-  fmpz_t* b2a_daBit(const size_t N, const bool* const x);
-  // Multiple bits (now no longer uses edaBits)
+  // Single bit. One round.
+  fmpz_t* b2a_daBit_single(const size_t N, const bool* const x);
+  // Multiple bits. Use a dabit per bit in parallel, so one round
+  fmpz_t* b2a_daBit_multi(const size_t N, const size_t* const num_bits,
+                          const fmpz_t* const x);
+  // Multiple bits. Uses one edabit, which requires L rounds for L bits.
   fmpz_t* b2a_edaBit(const size_t N, const size_t* const num_bits,
                      const fmpz_t* const x);
 
@@ -147,12 +150,6 @@ public:
   fmpz_t* b2a_ot(const size_t num_shares, const size_t num_values, 
                  const size_t* const num_bits, const fmpz_t* const shares,
                  const size_t mod = 0);
-
-  // Unused
-  // x2, xp, ret are [N]
-  // ret[i] is if xor shares x2[i] and additive shares xp[i] are the same value
-  // bool* validateSharesMatch(const size_t N, const size_t* const num_bits,
-  //                           const fmpz_t* const x2, const fmpz_t* const xp);
 };
 
 #endif

--- a/correlated.h
+++ b/correlated.h
@@ -67,7 +67,7 @@ class CorrelatedStore {
 
   // check if enough to make n. if not, call add
   void checkBoolTriples(const size_t n = 0);
-  void checkTriples(const size_t n = 0);
+  void checkTriples(const size_t n = 0, const bool always = false);
   void checkDaBits(const size_t n = 0);
   void checkEdaBits(const size_t num_bits, const size_t n = 0);
 

--- a/correlated.h
+++ b/correlated.h
@@ -1,7 +1,7 @@
 #ifndef CORRELATED_H
 #define CORRELATED_H
 
-/* 
+/*
 Correlated precomputes
 
 CorrelatedStore object, which has synced correlated precomputes between servers
@@ -118,7 +118,7 @@ public:
 
   // Using intsum_ot, multiple bits
   // TODO: shift mod to fmpz
-  fmpz_t* b2a_ot(const size_t num_shares, const size_t num_values, 
+  fmpz_t* b2a_ot(const size_t num_shares, const size_t num_values,
                  const size_t* const num_bits, const fmpz_t* const shares,
                  const size_t mod = 0);
 };

--- a/correlated.h
+++ b/correlated.h
@@ -136,9 +136,17 @@ public:
 
   // x, ret is [N]
   // Turns binary share x[i] into arith share ret[i]
+  // Single bit
   fmpz_t* b2a_daBit(const size_t N, const bool* const x);
+  // Multiple bits (now no longer uses edaBits)
   fmpz_t* b2a_edaBit(const size_t N, const size_t* const num_bits,
                      const fmpz_t* const x);
+
+  // Using intsum_ot, multiple bits
+  // TODO: shift mod to fmpz
+  fmpz_t* b2a_ot(const size_t num_shares, const size_t num_values, 
+                 const size_t* const num_bits, const fmpz_t* const shares,
+                 const size_t mod = 0);
 
   // Unused
   // x2, xp, ret are [N]

--- a/correlated.h
+++ b/correlated.h
@@ -115,8 +115,10 @@ public:
   EdaBit* getEdaBit(const size_t num_bits);
 
   void printSizes();
-  // Precompute if not enough
-  void maybeUpdate();
+  // Precompute if not enough.
+  // if eda = true, generates edabits
+  // otherwise makes dabits for dabit_multi
+  void maybeUpdate(const bool using_eda = false);
 
   // compute with store elements. Does batches of size N.
 

--- a/he_triples.cpp
+++ b/he_triples.cpp
@@ -1,3 +1,5 @@
+// Deprecated and unused
+
 #include "he_triples.h"
 
 #include <sys/wait.h>

--- a/he_triples.h
+++ b/he_triples.h
@@ -18,6 +18,8 @@ using namespace lbcrypto;
 /*
 A generator for Arithmetic triples, between two servers.
 
+Deprecated.
+
 Uses PALISADE's BFVrns encryption scheme.
 The plaintextModulus is the PARSEC Int_Modulus.
   Only supports < 60 bits.

--- a/net_share.cpp
+++ b/net_share.cpp
@@ -272,7 +272,7 @@ int send_seed(const int sockfd, const flint_rand_t x) {
 }
 
 int recv_seed(const int sockfd, flint_rand_t x) {
-    return recv_in(sockfd, &x[0], sizeof(x[0]));   
+    return recv_in(sockfd, &x[0], sizeof(x[0]));
 }
 
 /* Share functions */

--- a/ot.cpp
+++ b/ot.cpp
@@ -57,7 +57,7 @@ uint64_t bitsum_ot_sender(OT_Wrapper* const ot, const bool* const shares, const 
 
     const uint64_t max = mod == 0 ? UINT64_MAX : mod - 1;
 
-    emp::PRG prg(emp::fix_key);
+    emp::PRG prg;
 
     uint64_t sum = 0;
 
@@ -101,7 +101,7 @@ uint64_t bitsum_ot_receiver(OT_Wrapper* const ot, const bool* const shares, cons
     return sum;
 }
 
-uint64_t** intsum_ot_sender(OT_Wrapper* const ot, 
+uint64_t** intsum_ot_sender(OT_Wrapper* const ot,
                             const uint64_t* const * const shares,
                             const bool* const valid, const size_t* const num_bits,
                             const size_t num_shares, const size_t num_values,
@@ -145,7 +145,7 @@ uint64_t** intsum_ot_sender(OT_Wrapper* const ot,
                 const uint64_t minus_pow = max - pow + 1;
 
                 // b0 = share (1 << k) - r
-                prg.random_data(&b0[idx], sizeof(uint64_t));                
+                prg.random_data(&b0[idx], sizeof(uint64_t));
                 if (mod != 0) b0[idx] %= mod;
                 const uint64_t minus_b0 = max - b0[idx] + 1;
                 // b1 = (1 - share) (1 << k) - r
@@ -169,7 +169,7 @@ uint64_t** intsum_ot_sender(OT_Wrapper* const ot,
     return ret;
 }
 
-uint64_t** intsum_ot_receiver(OT_Wrapper* const ot, 
+uint64_t** intsum_ot_receiver(OT_Wrapper* const ot,
                               const uint64_t* const * const shares,
                               const size_t* const num_bits,
                               const size_t num_shares, const size_t num_values,

--- a/ot.cpp
+++ b/ot.cpp
@@ -53,7 +53,10 @@ void OT_Wrapper::recv(uint64_t* const data, const bool* b, const size_t length) 
 #error Not valid or defined OT type
 #endif
 
-uint64_t bitsum_ot_sender(OT_Wrapper* const ot, const bool* const shares, const bool* const valid, const size_t n){
+uint64_t bitsum_ot_sender(OT_Wrapper* const ot, const bool* const shares, const bool* const valid, const size_t n, const size_t mod){
+
+    const uint64_t max = mod == 0 ? UINT64_MAX : mod - 1;
+
     emp::PRG prg(emp::fix_key);
 
     uint64_t sum = 0;
@@ -65,8 +68,10 @@ uint64_t bitsum_ot_sender(OT_Wrapper* const ot, const bool* const shares, const 
 
         if (valid[i]) {
             prg.random_data(&b0[i], sizeof(uint64_t));
+            if (mod != 0) b0[i] %= mod;
             b1[i] = b0[i] + 1 - 2 * shares[i];
-            sum += (UINT64_MAX - b0[i]) + 1 + shares[i];
+            sum += (max - b0[i] + 1) + shares[i];
+            if (mod != 0) sum %= mod;
         } else {
             b0[i] = 0;
             b1[i] = 0;
@@ -80,53 +85,61 @@ uint64_t bitsum_ot_sender(OT_Wrapper* const ot, const bool* const shares, const 
     return sum;
 }
 
-uint64_t bitsum_ot_receiver(OT_Wrapper* const ot, const bool* const shares, const size_t n){
+uint64_t bitsum_ot_receiver(OT_Wrapper* const ot, const bool* const shares, const size_t n, const size_t mod){
     uint64_t* const r = new uint64_t[n];
     uint64_t sum = 0;
 
     ot->recv(r, shares, n);
 
-    for (unsigned int i = 0; i < n; i++)
+    for (unsigned int i = 0; i < n; i++) {
         sum += r[i];
+        if (mod != 0) sum %= mod;
+    }
 
     delete[] r;
 
     return sum;
 }
 
-uint64_t* intsum_ot_sender(OT_Wrapper* const ot,  const uint64_t* const shares,
-                           const bool* const valid, const size_t* const num_bits,
-                           const size_t num_shares, const size_t num_values) {
+uint64_t** intsum_ot_sender(OT_Wrapper* const ot, 
+                            const uint64_t* const * const shares,
+                            const bool* const valid, const size_t* const num_bits,
+                            const size_t num_shares, const size_t num_values,
+                            const size_t mod) {
     emp::PRG prg;
+
+    const uint64_t max = mod == 0 ? UINT64_MAX : mod - 1;
 
     size_t total_bits = 0;
     for (unsigned int j = 0; j < num_values; j++)
         total_bits += num_bits[j];
 
     uint64_t bool_share, r;
-    uint64_t* sum = new uint64_t[num_values];
-    memset(sum, 0, num_values * sizeof(uint64_t));
+    uint64_t** const ret = new uint64_t*[num_shares];
 
     uint64_t* const b0 = new uint64_t[num_shares * total_bits];
     uint64_t* const b1 = new uint64_t[num_shares * total_bits];
 
     size_t idx = 0;
     for (unsigned int i = 0; i < num_shares; i++) {
-        // std::cout << "valid[" << i << "] = " << valid[i] << std::endl;
+        ret[i] = new uint64_t[num_values];
+        memset(ret[i], 0, num_values * sizeof(uint64_t));
         for (unsigned int j = 0; j < num_values; j++) {
-            uint64_t num = shares[i * num_values + j];
-            // std::cout << "val[" << j << "] = " << num << std::endl;
+            uint64_t num = shares[i][j];
             for (unsigned int k = 0; k < num_bits[j]; k++) {
                 bool_share = num % 2;
                 num = num >> 1;
 
                 prg.random_data(&r, sizeof(uint64_t));
+                if (mod != 0) r %= mod;
+                const uint64_t minus_r = max - r + 1;
 
                 if (valid[i]) {
-                    b0[idx] = bool_share * (1ULL << k) - r;
-                    b1[idx] = (1 - bool_share) * (1ULL << k) - r;
+                    b0[idx] = bool_share * (1ULL << k) + minus_r;
+                    b1[idx] = (1 - bool_share) * (1ULL << k) + minus_r;
 
-                    sum[j] += r;
+                    ret[i][j] += r;
+                    if (mod != 0) ret[i][j] %= mod;
                 } else {
                     b0[idx] = 0;
                     b1[idx] = 0;
@@ -142,26 +155,26 @@ uint64_t* intsum_ot_sender(OT_Wrapper* const ot,  const uint64_t* const shares,
     delete[] b0;
     delete[] b1;
 
-    return sum;
+    return ret;
 }
 
-uint64_t* intsum_ot_receiver(OT_Wrapper* const ot, const uint64_t* const shares,
-                             const size_t* const num_bits,
-                             const size_t num_shares, const size_t num_values) {
+uint64_t** intsum_ot_receiver(OT_Wrapper* const ot, 
+                              const uint64_t* const * const shares,
+                              const size_t* const num_bits,
+                              const size_t num_shares, const size_t num_values,
+                              const size_t mod) {
     size_t total_bits = 0;
     for (unsigned int j = 0; j < num_values; j++)
         total_bits += num_bits[j];
 
     uint64_t* const r = new uint64_t[num_shares * total_bits];
     bool* const bool_shares = new bool[num_shares * total_bits];
-    uint64_t* sum = new uint64_t[num_values];
-    memset(sum, 0, num_values * sizeof(uint64_t));
+    uint64_t** const ret = new uint64_t*[num_shares];
 
     size_t idx = 0;
     for (unsigned int i = 0; i < num_shares; i++) {
         for (unsigned int j = 0; j < num_values; j++) {
-            uint64_t num = shares[i * num_values + j];
-            // std::cout << "val[" << j << "] = " << num << std::endl;
+            uint64_t num = shares[i][j];
             for (unsigned int k = 0; k < num_bits[j]; k++) {
                 bool_shares[idx] = num % 2;
                 num = num >> 1;
@@ -176,15 +189,18 @@ uint64_t* intsum_ot_receiver(OT_Wrapper* const ot, const uint64_t* const shares,
 
     idx = 0;
     for (unsigned int i = 0; i < num_shares; i++) {
+        ret[i] = new uint64_t[num_values];
+        memset(ret[i], 0, num_values * sizeof(uint64_t));
         for (unsigned int j = 0; j < num_values; j++) {
             for (unsigned int k = 0; k < num_bits[j]; k++) {
-                sum[j] += r[idx];
+                ret[i][j] += r[idx];
+                if (mod != 0) ret[i][j] %= mod;
                 idx++;
             }
         }
     }
     delete[] r;
-    return sum;
+    return ret;
 }
 
 // Ref : https://crypto.stackexchange.com/questions/41651/what-are-the-ways-to-generate-beaver-triples-for-multiplication-gate

--- a/ot.h
+++ b/ot.h
@@ -38,12 +38,12 @@ uint64_t bitsum_ot_receiver(OT_Wrapper* const ot, const bool* const shares, cons
 // valid: validity of share i
 // bits: length of value j
 // Does not accumulate
-uint64_t** intsum_ot_sender(OT_Wrapper* const ot, 
+uint64_t** intsum_ot_sender(OT_Wrapper* const ot,
                             const uint64_t* const * const shares,
                             const bool* const valid, const size_t* const num_bits,
                             const size_t num_shares, const size_t num_values,
                             const size_t mod = 0);
-uint64_t** intsum_ot_receiver(OT_Wrapper* const ot, 
+uint64_t** intsum_ot_receiver(OT_Wrapper* const ot,
                               const uint64_t* const * const shares,
                               const size_t* const num_bits,
                               const size_t num_shares, const size_t num_values,

--- a/ot.h
+++ b/ot.h
@@ -29,19 +29,25 @@ struct OT_Wrapper {
   void recv(uint64_t* const data, const bool* b, const size_t length);
 };
 
-uint64_t bitsum_ot_sender(OT_Wrapper* const ot, const bool* const shares, const bool* const valid, const size_t n);
-uint64_t bitsum_ot_receiver(OT_Wrapper* const ot, const bool* const shares, const size_t n);
+// mod 0 = default 2^64
+uint64_t bitsum_ot_sender(OT_Wrapper* const ot, const bool* const shares, const bool* const valid, const size_t n, const size_t mod = 0);
+uint64_t bitsum_ot_receiver(OT_Wrapper* const ot, const bool* const shares, const size_t n, const size_t mod = 0);
 
-// Batched version, for multiple values
-// shares: #shares * #values, as (s0v0, s0v1, s0v2, s1v0, ...)
+// Batched version, for multiple values per share
+// shares and ret: matrix of shares x values, as [s0v0, s0v1, s0v2], [s1v0, ...]
 // valid: validity of share i
 // bits: length of value j
-uint64_t* intsum_ot_sender(OT_Wrapper* const ot, const uint64_t* const shares,
-                           const bool* const valid, const size_t* const num_bits,
-                           const size_t num_shares, const size_t num_values);
-uint64_t* intsum_ot_receiver(OT_Wrapper* const ot, const uint64_t* const shares,
-                             const size_t* const num_bits,
-                             const size_t num_shares, const size_t num_values);
+// Does not accumulate
+uint64_t** intsum_ot_sender(OT_Wrapper* const ot, 
+                            const uint64_t* const * const shares,
+                            const bool* const valid, const size_t* const num_bits,
+                            const size_t num_shares, const size_t num_values,
+                            const size_t mod = 0);
+uint64_t** intsum_ot_receiver(OT_Wrapper* const ot, 
+                              const uint64_t* const * const shares,
+                              const size_t* const num_bits,
+                              const size_t num_shares, const size_t num_values,
+                              const size_t mod = 0);
 
 std::queue<BooleanBeaverTriple*> gen_boolean_beaver_triples(const int server_num, const unsigned int m, OT_Wrapper* const ot0, OT_Wrapper* const ot1);
 

--- a/server.cpp
+++ b/server.cpp
@@ -35,7 +35,7 @@ std::unordered_map<size_t, CheckerPreComp*> precomp_store;
 OT_Wrapper* ot0;
 OT_Wrapper* ot1;
 
-// Precompute cache of edabits and beaver triples
+// Precompute cache of dabits
 CorrelatedStore* correlated_store;
 // #define CACHE_SIZE 8192
 // #define CACHE_SIZE 65536
@@ -43,8 +43,6 @@ CorrelatedStore* correlated_store;
 #define CACHE_SIZE 2097152
 // If set, does fast but insecure offline precompute.
 #define LAZY_PRECOMPUTE true
-// Generate excess in case it runs out
-#define OVER_PRECOMPUTE false
 // Whether to use OT or Dabits
 #define USE_OT_B2A true
 
@@ -1235,7 +1233,7 @@ int main(int argc, char** argv) {
     ot0 = new OT_Wrapper(server_num == 0 ? nullptr : SERVER0_IP, 60051);
     ot1 = new OT_Wrapper(server_num == 1 ? nullptr : SERVER1_IP, 60052);
 
-    correlated_store = new CorrelatedStore(serverfd, server_num, ot0, ot1, num_bits, CACHE_SIZE, LAZY_PRECOMPUTE, true, OVER_PRECOMPUTE);
+    correlated_store = new CorrelatedStore(serverfd, server_num, ot0, ot1, num_bits, CACHE_SIZE, LAZY_PRECOMPUTE, true);
 
     int sockfd, newsockfd;
     sockaddr_in addr;

--- a/server.cpp
+++ b/server.cpp
@@ -171,7 +171,7 @@ fmpz_t* share_convert(const size_t num_shares,
         shares_p = correlated_store->b2a_ot(
             num_shares, num_values, num_bits, f_shares2, mod);
 
-    } else {  // edabit conversion
+    } else {  // dabit conversion
         size_t* const bits_arr = new size_t[num_shares * num_values];
         for (unsigned int i = 0; i < num_shares; i++)
             memcpy(&bits_arr[i * num_values], num_bits, num_values * sizeof(size_t));

--- a/server.cpp
+++ b/server.cpp
@@ -176,7 +176,7 @@ fmpz_t* share_convert(const size_t num_shares,
         for (unsigned int i = 0; i < num_shares; i++)
             memcpy(&bits_arr[i * num_values], num_bits, num_values * sizeof(size_t));
 
-        shares_p = correlated_store->b2a_edaBit(
+        shares_p = correlated_store->b2a_daBit_multi(
             num_shares * num_values, bits_arr, f_shares2);
 
         delete[] bits_arr;

--- a/server.h
+++ b/server.h
@@ -146,7 +146,7 @@ void syncSnipSeeds(const int serverfd, const int server_num) {
     if (server_num == 0)
         send_seed(serverfd, snips_seed);
     else
-        recv_seed(serverfd, snips_seed);   
+        recv_seed(serverfd, snips_seed);
 }
 
 struct Checker {

--- a/share.cpp
+++ b/share.cpp
@@ -99,6 +99,7 @@ void makeLocalDaBit(DaBit* const bit0, DaBit* const bit1) {
     fmpz_clear(bit);
 }
 
+// Deprecated
 void makeLocalEdaBit(EdaBit* const ebit0, EdaBit* const ebit1, const size_t n) {
     DaBit* bit0 = new DaBit();
     DaBit* bit1 = new DaBit();

--- a/share.h
+++ b/share.h
@@ -178,6 +178,7 @@ struct DaBit {
     }
 };
 
+// Deprecated. Multiple DaBits use less rounds
 struct EdaBit {
     fmpz_t r;        // [r]_p
     const size_t n;  // number of bits, length of b

--- a/test/test_bits.cpp
+++ b/test/test_bits.cpp
@@ -167,7 +167,7 @@ void test_addBinaryShares(const size_t N, const size_t* const nbits, const int s
   delete[] carry;
 }
 
-void test_b2a_daBit(const size_t N, const int server_num, const int serverfd, CorrelatedStore* store) {
+void test_b2a_daBit_single(const size_t N, const int server_num, const int serverfd, CorrelatedStore* store) {
   bool* x = new bool[N];
   if (server_num == 0) {
     x[0] = true; x[1] = false;
@@ -175,7 +175,7 @@ void test_b2a_daBit(const size_t N, const int server_num, const int serverfd, Co
     x[0] = true; x[1] = true;
   }
 
-  fmpz_t* xp = store->b2a_daBit(N, x);
+  fmpz_t* xp = store->b2a_daBit_single(N, x);
 
   if (server_num == 0) {
     fmpz_t tmp; fmpz_init(tmp);
@@ -201,7 +201,7 @@ void test_b2a_daBit(const size_t N, const int server_num, const int serverfd, Co
   clear_fmpz_array(xp, N);
 }
 
-void test_b2a_edaBit(const size_t N, const size_t* const nbits, const int server_num, const int serverfd, CorrelatedStore* store) {
+void test_b2a_multi(const size_t N, const size_t* const nbits, const int server_num, const int serverfd, CorrelatedStore* store, bool use_eda) {
   fmpz_t* x; new_fmpz_array(&x, N);
 
   if (server_num == 0) {
@@ -212,7 +212,12 @@ void test_b2a_edaBit(const size_t N, const size_t* const nbits, const int server
     fmpz_set_ui(x[1], 4);
   }
 
-  fmpz_t* xp = store->b2a_edaBit(N, nbits, x);
+  fmpz_t* xp;
+  if (use_eda) {
+    xp = store->b2a_edaBit(N, nbits, x);    
+  } else {
+    xp = store->b2a_daBit_multi(N, nbits, x);
+  }
 
   if (server_num == 0) {
     fmpz_t tmp; fmpz_init(tmp);
@@ -303,10 +308,13 @@ void runServerTest(const int server_num, const int serverfd) {
     test_addBinaryShares(N, bits_arr, server_num, serverfd, store);
     std::cout << "add bin timing : " << sec_from(start) << std::endl; start = clock_start();
     // std::cout << "b2a da" << std::endl;
-    test_b2a_daBit(N, server_num, serverfd, store);
-    std::cout << "b2a da timing : " << sec_from(start) << std::endl; start = clock_start();
+    test_b2a_daBit_single(N, server_num, serverfd, store);
+    std::cout << "b2a da single timing : " << sec_from(start) << std::endl; start = clock_start();
     
-    test_b2a_edaBit(N, bits_arr, server_num, serverfd, store);
+    test_b2a_multi(N, bits_arr, server_num, serverfd, store, false);
+    std::cout << "b2a da multi timing : " << sec_from(start) << std::endl; start = clock_start();
+
+    test_b2a_multi(N, bits_arr, server_num, serverfd, store, true);
     std::cout << "b2a eda timing : " << sec_from(start) << std::endl; start = clock_start();
 
     test_b2a_ot(N, bits_arr, server_num, serverfd, store);

--- a/test/test_bits.cpp
+++ b/test/test_bits.cpp
@@ -297,8 +297,8 @@ void runServerTest(const int server_num, const int serverfd) {
     test_b2a_daBit(N, server_num, serverfd, store);
     std::cout << "b2a da timing : " << sec_from(start) << std::endl; start = clock_start();
     // std::cout << "b2a ed" << std::endl;
-    test_b2a_edaBit(N, bits_arr, server_num, serverfd, store);
-    std::cout << "b2a eda timing : " << sec_from(start) << std::endl; start = clock_start();
+    // test_b2a_edaBit(N, bits_arr, server_num, serverfd, store);
+    // std::cout << "b2a eda timing : " << sec_from(start) << std::endl; start = clock_start();
     // std::cout << "validate" << std::endl;
     // test_validateSharesMatch(N, bits_arr, server_num, serverfd, store);
   }

--- a/test/test_bits.cpp
+++ b/test/test_bits.cpp
@@ -284,6 +284,7 @@ void runServerTest(const int server_num, const int serverfd) {
   OT_Wrapper* ot1 = new OT_Wrapper(server_num == 1 ? nullptr : "127.0.0.1", 60052);
   CorrelatedStore* store = new CorrelatedStore(serverfd, server_num, ot0, ot1, num_bits, batch_size, lazy, do_fork, over_precompute);
 
+  store->maybeUpdate(true);
   store->maybeUpdate();
 
   std::cout << std::endl;
@@ -298,16 +299,16 @@ void runServerTest(const int server_num, const int serverfd) {
   for (int i = 0; i < 1; i++) {
     std::cout << "iteration: " << i << std::endl;
     start = clock_start();
-    // std::cout << "mul bool" << std::endl;
+
     test_multiplyBoolShares(N, server_num, serverfd, store);
     std::cout << "mul bool timing : " << sec_from(start) << std::endl; start = clock_start();
-    // std::cout << "mul arith" << std::endl;
+
     test_multiplyArithmeticShares(N, server_num, serverfd, store);
     std::cout << "mul arith timing : " << sec_from(start) << std::endl; start = clock_start();
-    // std::cout << "add bin" << std::endl;
+
     test_addBinaryShares(N, bits_arr, server_num, serverfd, store);
     std::cout << "add bin timing : " << sec_from(start) << std::endl; start = clock_start();
-    // std::cout << "b2a da" << std::endl;
+
     test_b2a_daBit_single(N, server_num, serverfd, store);
     std::cout << "b2a da single timing : " << sec_from(start) << std::endl; start = clock_start();
     

--- a/test/test_bits.cpp
+++ b/test/test_bits.cpp
@@ -262,7 +262,7 @@ void runServerTest(const int server_num, const int serverfd) {
 
     test_b2a_daBit_single(N, server_num, serverfd, store);
     std::cout << "b2a da single timing : " << sec_from(start) << std::endl; start = clock_start();
-    
+
     test_b2a_multi(N, bits_arr, server_num, serverfd, store);
     std::cout << "b2a da multi timing : " << sec_from(start) << std::endl; start = clock_start();
 

--- a/test/test_ot.cpp
+++ b/test/test_ot.cpp
@@ -19,52 +19,6 @@ void run_server0(const size_t m) {
   OT_Wrapper* ot0 = new OT_Wrapper(server_num == 0 ? nullptr : SERVER0_IP, 60051);
   OT_Wrapper* ot1 = new OT_Wrapper(server_num == 1 ? nullptr : SERVER1_IP, 60052);
 
-  // gen beaver triple
-  // auto triples = gen_boolean_beaver_triples(server_num, m, ot0, ot1);
-
-  // std::cout << "Validating bool triples" << std::endl;
-  // BooleanBeaverTriple* other_triple = new BooleanBeaverTriple();
-  // for (int i = 0; i < m; i++) {
-  //   recv_BooleanBeaverTriple(cli_sockfd, other_triple);
-  //   BooleanBeaverTriple* triple = triples.front();
-  //   triples.pop();
-  //   std::cout << "ab = (" << triple->a << " ^ " << other_triple->a << ") * (";
-  //   std::cout << triple->b << " ^ " << other_triple->b << ") = ";
-  //   std::cout << ((triple->a ^ other_triple->a) & (triple->b ^ other_triple->b));
-  //   std::cout << ", vs c = " << triple->c << " ^ " << other_triple->c << " = " << (triple->c ^ other_triple->c) << std::endl;
-  // }
-  // delete other_triple;
-
-  // // gen arith triple
-
-  // std::cout << "Making arith triple" << std::endl;
-  // BeaverTriple* btriple = generate_beaver_triple_lazy(cli_sockfd, server_num);
-  // std::cout << "Validating lazy arith triple" << std::endl;
-  // BeaverTriple* other_btriple = new BeaverTriple();
-  // recv_BeaverTriple(cli_sockfd, other_btriple);
-
-  // fmpz_t tmp; fmpz_init(tmp);
-  // fmpz_t tmp2; fmpz_init(tmp2);
-  // fmpz_add(tmp, btriple->A, other_btriple->A);
-  // fmpz_mod(tmp, tmp, Int_Modulus);
-  // fmpz_add(tmp2, btriple->B, other_btriple->B);
-  // fmpz_mod(tmp2, tmp2, Int_Modulus);
-  // fmpz_mul(tmp, tmp, tmp2);
-  // fmpz_mod(tmp, tmp, Int_Modulus);
-  // std::cout << "actual product: ("; fmpz_print(btriple->A);
-  // std::cout << " + "; fmpz_print(other_btriple->A);
-  // std::cout << ") * ("; fmpz_print(btriple->B);
-  // std::cout << " + "; fmpz_print(other_btriple->B);
-  // std::cout << ") = "; fmpz_print(tmp);
-  // std::cout << std::endl;
-  // fmpz_add(tmp, btriple->C, other_btriple->C);
-  // fmpz_mod(tmp, tmp, Int_Modulus);
-  // fmpz_print(btriple->C); std::cout << " + "; fmpz_print(other_btriple->C);
-  // std::cout << " = "; fmpz_print(tmp); std::cout << std::endl;
-
-  // delete other_btriple;
-  // delete btriple;
-
   // Bitsum OT
   const bool valid[1] = {true};
 
@@ -112,18 +66,6 @@ void run_server1(const size_t m) {
 
   OT_Wrapper* ot0 = new OT_Wrapper(server_num == 0 ? nullptr : SERVER0_IP, 60051);
   OT_Wrapper* ot1 = new OT_Wrapper(server_num == 1 ? nullptr : SERVER1_IP, 60052);
-
-  // auto triples = gen_boolean_beaver_triples(server_num, m, ot0, ot1);
-  // for (int i = 0; i < m; i++) {
-  //   BooleanBeaverTriple* triple = triples.front();
-  //   triples.pop();
-  //   send_BooleanBeaverTriple(newsockfd, triple);
-  //   delete triple;
-  // }
-
-  // BeaverTriple* btriple = generate_beaver_triple_lazy(newsockfd, server_num);
-  // send_BeaverTriple(newsockfd, btriple);
-  // delete btriple;
 
   const bool bitshares[1] = {m % 2 ? true : false};
   std::cout << "bit share1[0] = " << bitshares[0] << std::endl;

--- a/test/test_ot.cpp
+++ b/test/test_ot.cpp
@@ -8,8 +8,149 @@
 #define SERVER0_IP "127.0.0.1"
 #define SERVER1_IP "127.0.0.1"
 
+const size_t MOD = 100;
+// const size_t MOD = 0;  // 2^64, default
+
+void run_server0(const size_t m) {
+  const int server_num = 0;
+
+  int cli_sockfd = init_sender();
+
+  OT_Wrapper* ot0 = new OT_Wrapper(server_num == 0 ? nullptr : SERVER0_IP, 60051);
+  OT_Wrapper* ot1 = new OT_Wrapper(server_num == 1 ? nullptr : SERVER1_IP, 60052);
+
+  // gen beaver triple
+  // auto triples = gen_boolean_beaver_triples(server_num, m, ot0, ot1);
+
+  // std::cout << "Validating bool triples" << std::endl;
+  // BooleanBeaverTriple* other_triple = new BooleanBeaverTriple();
+  // for (int i = 0; i < m; i++) {
+  //   recv_BooleanBeaverTriple(cli_sockfd, other_triple);
+  //   BooleanBeaverTriple* triple = triples.front();
+  //   triples.pop();
+  //   std::cout << "ab = (" << triple->a << " ^ " << other_triple->a << ") * (";
+  //   std::cout << triple->b << " ^ " << other_triple->b << ") = ";
+  //   std::cout << ((triple->a ^ other_triple->a) & (triple->b ^ other_triple->b));
+  //   std::cout << ", vs c = " << triple->c << " ^ " << other_triple->c << " = " << (triple->c ^ other_triple->c) << std::endl;
+  // }
+  // delete other_triple;
+
+  // // gen arith triple
+
+  // std::cout << "Making arith triple" << std::endl;
+  // BeaverTriple* btriple = generate_beaver_triple_lazy(cli_sockfd, server_num);
+  // std::cout << "Validating lazy arith triple" << std::endl;
+  // BeaverTriple* other_btriple = new BeaverTriple();
+  // recv_BeaverTriple(cli_sockfd, other_btriple);
+
+  // fmpz_t tmp; fmpz_init(tmp);
+  // fmpz_t tmp2; fmpz_init(tmp2);
+  // fmpz_add(tmp, btriple->A, other_btriple->A);
+  // fmpz_mod(tmp, tmp, Int_Modulus);
+  // fmpz_add(tmp2, btriple->B, other_btriple->B);
+  // fmpz_mod(tmp2, tmp2, Int_Modulus);
+  // fmpz_mul(tmp, tmp, tmp2);
+  // fmpz_mod(tmp, tmp, Int_Modulus);
+  // std::cout << "actual product: ("; fmpz_print(btriple->A);
+  // std::cout << " + "; fmpz_print(other_btriple->A);
+  // std::cout << ") * ("; fmpz_print(btriple->B);
+  // std::cout << " + "; fmpz_print(other_btriple->B);
+  // std::cout << ") = "; fmpz_print(tmp);
+  // std::cout << std::endl;
+  // fmpz_add(tmp, btriple->C, other_btriple->C);
+  // fmpz_mod(tmp, tmp, Int_Modulus);
+  // fmpz_print(btriple->C); std::cout << " + "; fmpz_print(other_btriple->C);
+  // std::cout << " = "; fmpz_print(tmp); std::cout << std::endl;
+
+  // delete other_btriple;
+  // delete btriple;
+
+  // Bitsum OT
+  const bool valid[1] = {true};
+
+  std::cout << "Testing bit OT convert" << std::endl;
+  const bool bitshares[1] = {(m / 2) % 2 ? true : false};
+  std::cout << "bit share0[0] = " << bitshares[0] << std::endl;
+  const uint64_t a = bitsum_ot_sender(ot0, bitshares, valid, 1, MOD);
+  uint64_t b;
+  recv_uint64(cli_sockfd, b);
+  std::cout << "bit have a = " << a << std::endl;
+  std::cout << "bit got  b = " << b << std::endl;
+  std::cout << "bit ans: " << a + b << std::endl;
+
+  // Intsum OT
+
+  std::cout << "Testing int OT convert" << std::endl;
+  // const uint64_t intshares[1][1] = {{m ^ 9}};
+  uint64_t** const intshares = new uint64_t*[1];
+  intshares[0] = new uint64_t[1];
+  intshares[0][0] = m ^ 9;
+  const size_t sizes[1] = {4};
+  std::cout << "int share0[0] = " << intshares[0][0] << std::endl;
+  uint64_t** int_a = intsum_ot_sender(ot0, intshares, valid, sizes, 1, 1, MOD);
+  delete[] intshares[0];
+  delete[] intshares;
+  recv_uint64(cli_sockfd, b);
+  std::cout << "int have a = " << int_a[0][0] << std::endl;
+  std::cout << "int got  b = " << b << std::endl;
+  std::cout << "int ans: " << int_a[0][0] + b << std::endl;
+  delete[] int_a[0];
+  delete[] int_a;
+
+  // cleanup
+
+  delete ot0;
+  delete ot1;
+  close(cli_sockfd);
+}
+
+void run_server1(const size_t m) {
+  const int server_num = 1;
+
+  int sockfd = init_receiver();
+  int newsockfd = accept_receiver(sockfd);
+
+  OT_Wrapper* ot0 = new OT_Wrapper(server_num == 0 ? nullptr : SERVER0_IP, 60051);
+  OT_Wrapper* ot1 = new OT_Wrapper(server_num == 1 ? nullptr : SERVER1_IP, 60052);
+
+  // auto triples = gen_boolean_beaver_triples(server_num, m, ot0, ot1);
+  // for (int i = 0; i < m; i++) {
+  //   BooleanBeaverTriple* triple = triples.front();
+  //   triples.pop();
+  //   send_BooleanBeaverTriple(newsockfd, triple);
+  //   delete triple;
+  // }
+
+  // BeaverTriple* btriple = generate_beaver_triple_lazy(newsockfd, server_num);
+  // send_BeaverTriple(newsockfd, btriple);
+  // delete btriple;
+
+  const bool bitshares[1] = {m % 2 ? true : false};
+  std::cout << "bit share1[0] = " << bitshares[0] << std::endl;
+  const uint64_t b = bitsum_ot_receiver(ot0, bitshares, 1, MOD);
+  send_uint64(newsockfd, b);
+
+  // const uint64_t intshares[1][1] = {{9}};
+  uint64_t** const intshares = new uint64_t*[9];
+  intshares[0] = new uint64_t[1];
+  intshares[0][0] = 9;
+  const size_t sizes[1] = {4};
+  std::cout << "int share1[0] = " << intshares[0][0] << std::endl;
+  uint64_t** int_b = intsum_ot_receiver(ot0, intshares, sizes, 1, 1, MOD);
+  delete[] intshares[0];
+  delete[] intshares;
+  send_uint64(newsockfd, int_b[0][0]);
+  delete[] int_b[0];
+  delete[] int_b;
+
+  delete ot0;
+  delete ot1;
+  close(sockfd);
+  close(newsockfd);
+}
+
 int main(int argc, char** argv){
-  int m = 10;
+  int m = 4;
   if(argc >= 2){
     m = atoi(argv[1]);
   }
@@ -17,86 +158,12 @@ int main(int argc, char** argv){
   init_constants();
 
   pid_t pid = fork();
-  int server_num = (pid == 0 ? 0 : 1);
-
-  std::cout << "Making io objects" << std::endl;
-
-  OT_Wrapper* ot0 = new OT_Wrapper(server_num == 0 ? nullptr : SERVER0_IP, 60051);
-  OT_Wrapper* ot1 = new OT_Wrapper(server_num == 1 ? nullptr : SERVER1_IP, 60052);
-
-  std::cout << "Making bool triples" << std::endl;
-
-  auto triples = gen_boolean_beaver_triples(server_num, m, ot0, ot1);
 
   if (pid == 0) {
-    sleep(1);
-    int cli_sockfd = init_sender();
-
-    std::cout << "Validating bool triples" << std::endl;
-    BooleanBeaverTriple* other_triple = new BooleanBeaverTriple();
-    for (int i = 0; i < m; i++) {
-      recv_BooleanBeaverTriple(cli_sockfd, other_triple);
-      BooleanBeaverTriple* triple = triples.front();
-      triples.pop();
-      std::cout << "ab = (" << triple->a << " ^ " << other_triple->a << ") * (";
-      std::cout << triple->b << " ^ " << other_triple->b << ") = ";
-      std::cout << ((triple->a ^ other_triple->a) & (triple->b ^ other_triple->b));
-      std::cout << ", vs c = " << triple->c << " ^ " << other_triple->c << " = " << (triple->c ^ other_triple->c) << std::endl;
-    }
-    delete other_triple;
-
-    std::cout << "Making arith triple" << std::endl;
-    BeaverTriple* btriple = generate_beaver_triple_lazy(cli_sockfd, server_num);
-    std::cout << "Validating arith triple" << std::endl;
-    BeaverTriple* other_btriple = new BeaverTriple();
-    recv_BeaverTriple(cli_sockfd, other_btriple);
-
-    fmpz_t tmp; fmpz_init(tmp);
-    fmpz_t tmp2; fmpz_init(tmp2);
-    fmpz_add(tmp, btriple->A, other_btriple->A);
-    fmpz_mod(tmp, tmp, Int_Modulus);
-    fmpz_add(tmp2, btriple->B, other_btriple->B);
-    fmpz_mod(tmp2, tmp2, Int_Modulus);
-    fmpz_mul(tmp, tmp, tmp2);
-    fmpz_mod(tmp, tmp, Int_Modulus);
-    std::cout << "actual product: ("; fmpz_print(btriple->A);
-    std::cout << " + "; fmpz_print(other_btriple->A);
-    std::cout << ") * ("; fmpz_print(btriple->B);
-    std::cout << " + "; fmpz_print(other_btriple->B);
-    std::cout << ") = "; fmpz_print(tmp);
-    std::cout << std::endl;
-    fmpz_add(tmp, btriple->C, other_btriple->C);
-    fmpz_mod(tmp, tmp, Int_Modulus);
-    fmpz_print(btriple->C); std::cout << " + "; fmpz_print(other_btriple->C);
-    std::cout << " = "; fmpz_print(tmp); std::cout << std::endl;
-
-    delete other_btriple;
-    delete btriple;
-
-    close(cli_sockfd);
+    run_server0(m);
   } else {
-    int sockfd = init_receiver();
-    int newsockfd = accept_receiver(sockfd);
-
-    for (int i = 0; i < m; i++) {
-      BooleanBeaverTriple* triple = triples.front();
-      triples.pop();
-      send_BooleanBeaverTriple(newsockfd, triple);
-      delete triple;
-    }
-
-    BeaverTriple* btriple = generate_beaver_triple_lazy(newsockfd, server_num);
-
-    send_BeaverTriple(newsockfd, btriple);
-
-    delete btriple;
-
-    close(sockfd);
-    close(newsockfd);
+    run_server1(m);
   }
-
-  delete ot0;
-  delete ot1;
 
   clear_constants();
 

--- a/test/test_ot.cpp
+++ b/test/test_ot.cpp
@@ -8,8 +8,8 @@
 #define SERVER0_IP "127.0.0.1"
 #define SERVER1_IP "127.0.0.1"
 
-const size_t MOD = 100;
-// const size_t MOD = 0;  // 2^64, default
+#define MOD 100
+// #define MOD 0  // 2^64, default
 
 void run_server0(const size_t m) {
   const int server_num = 0;
@@ -130,7 +130,6 @@ void run_server1(const size_t m) {
   const uint64_t b = bitsum_ot_receiver(ot0, bitshares, 1, MOD);
   send_uint64(newsockfd, b);
 
-  // const uint64_t intshares[1][1] = {{9}};
   uint64_t** const intshares = new uint64_t*[9];
   intshares[0] = new uint64_t[1];
   intshares[0][0] = 9;

--- a/utils.h
+++ b/utils.h
@@ -16,4 +16,4 @@ inline void error_exit(const char* const msg) {
 
 // todo: possibly connection code, from utils test connect and others?
 
-#endif 
+#endif


### PR DESCRIPTION
- Use L dabits rather than an L bit edaBit for b2A of L bit numbers
  - Requires 1 round with batching rather than L rounds using adder circuit
  - Removes need for edaBits and boolean beaver triples
  - Generally faster
- Improved dabit generation
  - Use OT rather than arithmetic beaver triples
  - Removes need for arith beaver triples, and therefore the Palisade SHE dependency
  - Currently still ~64 bit max for OT use, though can be expanded to 128
  - Much faster total since don't need arith/SHE triples
- Some framework for b2a_ot
  - existing intsum and bitsum use this already, just put in similar layout
  - support for mod p b2a_ot. Unused. 
  - dabit is more efficient online, but can use either
